### PR TITLE
Added logos and descriptions for payment methods

### DIFF
--- a/Block/QuickPay.php
+++ b/Block/QuickPay.php
@@ -4,44 +4,24 @@ declare(strict_types=1);
 
 namespace Magebit\CheckoutQuickPayPayment\Block;
 
-use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\View\Asset\Repository as AssetRepository;
 use Magento\Store\Model\ScopeInterface;
+use QuickPay\Gateway\Model\Ui\ConfigProvider;
 
 class QuickPay extends Template
 {
-    public const CODE = 'quickpay_gateway';
-    public const CODE_KLARNA = 'quickpay_klarna';
-    public const CODE_APPLEPAY = 'quickpay_applepay';
-    public const CODE_MOBILEPAY = 'quickpay_mobilepay';
-    public const CODE_VIPPS = 'quickpay_vipps';
-    public const CODE_PAYPAL = 'quickpay_paypal';
-    public const CODE_VIABILL = 'quickpay_viabill';
-    public const CODE_SWISH = 'quickpay_swish';
-    public const CODE_TRUSTLY = 'quickpay_trustly';
-    public const CODE_ANYDAY = 'quickpay_anyday';
-    public const CODE_GOOGLEPAY = 'quickpay_googlepay';
-
-    private const XML_PATH_CARD_LOGO = 'payment/quickpay_gateway/cardlogos';
-    private const XML_PATH_DESCRIPTION = 'payment/%s/description';
-
     /**
      * @var ScopeConfigInterface
-     *
-    protected  $scopeConfig;
+     */
+    protected $scopeConfig;
 
     /**
      * @var AssetRepository
      */
-    protected  $assetRepo;
-
-    /**
-     * @var Escaper
-     */
-    protected $escaper;
+    protected $assetRepo;
 
     /**
      * QuickPay constructor.
@@ -49,98 +29,91 @@ class QuickPay extends Template
      * @param Context $context
      * @param ScopeConfigInterface $scopeConfig
      * @param AssetRepository $assetRepo
-     * @param Escaper $escaper       
-     * @param array $data
      */
     public function __construct(
         Context $context,
         ScopeConfigInterface $scopeConfig,
         AssetRepository $assetRepo,
-        Escaper $escaper,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->scopeConfig = $scopeConfig;
         $this->assetRepo = $assetRepo;
-        $this->escaper = $escaper;
     }
 
     /**
-     * Return the description for a payment method
+     * Get the description for a specific payment method
+     *
+     * @param string $methodCode
+     * @return string
      */
-    public function getDescription($methodCode)
+    public function getDescription(string $methodCode)
     {
         return (string)$this->scopeConfig->getValue(
-            sprintf(self::XML_PATH_DESCRIPTION, $methodCode),
+            sprintf(ConfigProvider::XML_PATH_DESCRIPTION, $methodCode),
             ScopeInterface::SCOPE_STORE
         );
     }
 
     /**
-     * Return payment logo and description based on selected payment method
+     * Return payment logo, label, and description based on selected payment method
+     *
+     * @param string $methodCode
+     * @return array
      */
-    public function getPaymentConfigByMethod($methodCode)
+    public function getPaymentConfigByMethod(string $methodCode)
     {
-        $logo = [];
         $description = $this->getDescription($methodCode);
+        $label = '';
+        $logo = [];
 
-        switch ($methodCode) {
-            case self::CODE:
-                $logo = $this->getQuickPayCardLogo();
-                break;
-
-            case self::CODE_KLARNA:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/klarna.svg')];
-                break;
-
-            case self::CODE_APPLEPAY:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/apple-pay.svg')];
-                break;
-
-            case self::CODE_MOBILEPAY:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/mobilepay_payment.png')];
-                break;
-
-            case self::CODE_VIPPS:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/vipps.png')];
-                break;
-
-            case self::CODE_PAYPAL:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/paypal.svg')];
-                break;
-
-            case self::CODE_VIABILL:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/viabill.png')];
-                break;
-
-            case self::CODE_SWISH:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/swish.png')];
-                break;
-
-            case self::CODE_TRUSTLY:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/trustly.svg')];
-                break;
-
-            case self::CODE_ANYDAY:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/anydaysplit.svg')];
-                break;
-
-            case self::CODE_GOOGLEPAY:
-                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/google-pay.svg')];
-                break;
+        if ($methodCode === ConfigProvider::CODE) {
+            $logo = $this->getQuickPayCardLogo();
+            $label = __('QuickPay'); // Default label for main gateway
+        } else {
+            $map = $this->getMethodLogoMap();
+            if (isset($map[$methodCode])) {
+                $logo = [$this->assetRepo->getUrl("QuickPay_Gateway::images/{$map[$methodCode]['logo']}")];
+                $label = $map[$methodCode]['label'];
+            }
         }
+
         return [
             'paymentLogo' => $logo,
-            'description' => $description
+            'description' => $description,
+            'label'       => $label,
+        ];
+    }
+
+    /**
+     * Get mapping of payment methods to their logo files and labels
+     *
+     * @return array
+     */
+    private function getMethodLogoMap()
+    {
+        return [
+            ConfigProvider::CODE_KLARNA    => ['logo' => 'klarna.svg', 'label' => 'Klarna'],
+            ConfigProvider::CODE_APPLEPAY  => ['logo' => 'apple-pay.svg', 'label' => 'Apple Pay'],
+            ConfigProvider::CODE_MOBILEPAY => ['logo' => 'mobilepay_payment.png', 'label' => 'MobilePay'],
+            ConfigProvider::CODE_VIPPS     => ['logo' => 'vipps.png', 'label' => 'Vipps'],
+            ConfigProvider::CODE_PAYPAL    => ['logo' => 'paypal.svg', 'label' => 'PayPal'],
+            ConfigProvider::CODE_VIABILL   => ['logo' => 'viabill.png', 'label' => 'ViaBill'],
+            ConfigProvider::CODE_SWISH     => ['logo' => 'swish.png', 'label' => 'Swish'],
+            ConfigProvider::CODE_TRUSTLY   => ['logo' => 'trustly.svg', 'label' => 'Trustly'],
+            ConfigProvider::CODE_ANYDAY    => ['logo' => 'anydaysplit.svg', 'label' => 'Anyday'],
+            ConfigProvider::CODE_GOOGLEPAY => ['logo' => 'google-pay.svg', 'label' => 'Google Pay'],
         ];
     }
 
     /**
      * Return logos for main QuickPay gateway
+     *
+     * @return array
      */
     protected function getQuickPayCardLogo()
     {
-        $cards = explode(',', (string)$this->scopeConfig->getValue(self::XML_PATH_CARD_LOGO, ScopeInterface::SCOPE_STORE));
+        $cards = explode(',', (string)$this->scopeConfig->getValue(ConfigProvider::XML_PATH_CARD_LOGO, ScopeInterface::SCOPE_STORE));
         $cardsSvg = ['maestro', 'mastercard', 'visa'];
         $items = [];
 

--- a/Block/QuickPay.php
+++ b/Block/QuickPay.php
@@ -154,37 +154,4 @@ class QuickPay extends Template
 
         return $items;
     }
-
-    /**
-     * Escape HTML safely
-     *
-     * @param string $value
-     * @return string
-     */
-    public function escHtml($value)
-    {
-        return $this->escaper->escapeHtml($value);
-    }
-
-    /**
-     * Escape HTML attribute safely
-     *
-     * @param string $value
-     * @return string
-     */
-    public function escAttr($value)
-    {
-        return $this->escaper->escapeHtmlAttr($value);
-    }
-
-    /**
-     * Escape URL safely
-     *
-     * @param string $url
-     * @return string
-     */
-    public function escUrl($url)
-    {
-        return $this->escaper->escapeUrl($url);
-    }
 }

--- a/Block/QuickPay.php
+++ b/Block/QuickPay.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Magebit\CheckoutQuickPayPayment\Block;
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\View\Asset\Repository as AssetRepository;
+use Magento\Store\Model\ScopeInterface;
+
+class QuickPay extends Template
+{
+    public const CODE = 'quickpay_gateway';
+    public const CODE_KLARNA = 'quickpay_klarna';
+    public const CODE_APPLEPAY = 'quickpay_applepay';
+    public const CODE_MOBILEPAY = 'quickpay_mobilepay';
+    public const CODE_VIPPS = 'quickpay_vipps';
+    public const CODE_PAYPAL = 'quickpay_paypal';
+    public const CODE_VIABILL = 'quickpay_viabill';
+    public const CODE_SWISH = 'quickpay_swish';
+    public const CODE_TRUSTLY = 'quickpay_trustly';
+    public const CODE_ANYDAY = 'quickpay_anyday';
+    public const CODE_GOOGLEPAY = 'quickpay_googlepay';
+
+    private const XML_PATH_CARD_LOGO = 'payment/quickpay_gateway/cardlogos';
+    private const XML_PATH_DESCRIPTION = 'payment/%s/description';
+
+    /**
+     * @var ScopeConfigInterface
+     *
+    protected  $scopeConfig;
+
+    /**
+     * @var AssetRepository
+     */
+    protected  $assetRepo;
+
+    /**
+     * @var Escaper
+     */
+    protected $escaper;
+
+    /**
+     * QuickPay constructor.
+     *
+     * @param Context $context
+     * @param ScopeConfigInterface $scopeConfig
+     * @param AssetRepository $assetRepo
+     * @param Escaper $escaper       
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        ScopeConfigInterface $scopeConfig,
+        AssetRepository $assetRepo,
+        Escaper $escaper,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->scopeConfig = $scopeConfig;
+        $this->assetRepo = $assetRepo;
+        $this->escaper = $escaper;
+    }
+
+    /**
+     * Return the description for a payment method
+     */
+    public function getDescription($methodCode)
+    {
+        return (string)$this->scopeConfig->getValue(
+            sprintf(self::XML_PATH_DESCRIPTION, $methodCode),
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * Return payment logo and description based on selected payment method
+     */
+    public function getPaymentConfigByMethod($methodCode)
+    {
+        $logo = [];
+        $description = $this->getDescription($methodCode);
+
+        switch ($methodCode) {
+            case self::CODE:
+                $logo = $this->getQuickPayCardLogo();
+                break;
+
+            case self::CODE_KLARNA:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/klarna.svg')];
+                break;
+
+            case self::CODE_APPLEPAY:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/apple-pay.svg')];
+                break;
+
+            case self::CODE_MOBILEPAY:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/mobilepay_payment.png')];
+                break;
+
+            case self::CODE_VIPPS:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/vipps.png')];
+                break;
+
+            case self::CODE_PAYPAL:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/paypal.svg')];
+                break;
+
+            case self::CODE_VIABILL:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/viabill.png')];
+                break;
+
+            case self::CODE_SWISH:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/swish.png')];
+                break;
+
+            case self::CODE_TRUSTLY:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/trustly.svg')];
+                break;
+
+            case self::CODE_ANYDAY:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/anydaysplit.svg')];
+                break;
+
+            case self::CODE_GOOGLEPAY:
+                $logo = [$this->assetRepo->getUrl('QuickPay_Gateway::images/google-pay.svg')];
+                break;
+        }
+        return [
+            'paymentLogo' => $logo,
+            'description' => $description
+        ];
+    }
+
+    /**
+     * Return logos for main QuickPay gateway
+     */
+    protected function getQuickPayCardLogo()
+    {
+        $cards = explode(',', (string)$this->scopeConfig->getValue(self::XML_PATH_CARD_LOGO, ScopeInterface::SCOPE_STORE));
+        $cardsSvg = ['maestro', 'mastercard', 'visa'];
+        $items = [];
+
+        foreach ($cards as $card) {
+            $card = trim($card);
+            if ($card !== '') {
+                $ext = in_array($card, $cardsSvg, true) ? 'svg' : 'png';
+                $items[] = $this->assetRepo->getUrl("QuickPay_Gateway::images/logo/{$card}.{$ext}");
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Escape HTML safely
+     *
+     * @param string $value
+     * @return string
+     */
+    public function escHtml($value)
+    {
+        return $this->escaper->escapeHtml($value);
+    }
+
+    /**
+     * Escape HTML attribute safely
+     *
+     * @param string $value
+     * @return string
+     */
+    public function escAttr($value)
+    {
+        return $this->escaper->escapeHtmlAttr($value);
+    }
+
+    /**
+     * Escape URL safely
+     *
+     * @param string $url
+     * @return string
+     */
+    public function escUrl($url)
+    {
+        return $this->escaper->escapeUrl($url);
+    }
+}

--- a/view/frontend/layout/hyva_checkout_components.xml
+++ b/view/frontend/layout/hyva_checkout_components.xml
@@ -8,11 +8,95 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
+       <body>
         <referenceBlock name="checkout.payment.methods">
-            <block name="checkout.payment.method.quickpay"
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay" name="checkout.payment.method.quickpay_gateway"
                    as="quickpay_gateway"
-                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml"/>
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_gateway</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_klarna"
+                   as="quickpay_klarna"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_klarna</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_applepay"
+                   as="quickpay_applepay"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_applepay</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_mobilepay"
+                   as="quickpay_mobilepay"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_mobilepay</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_vipps"
+                   as="quickpay_vipps"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_vipps</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_paypal"
+                   as="quickpay_paypal"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_paypal</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_viabill"
+                   as="quickpay_viabill"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_viabill</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_swish"
+                   as="quickpay_swish"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_swish</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_trustly"
+                   as="quickpay_trustly"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_trustly</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_anyday"
+                   as="quickpay_anyday"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_anyday</argument>
+                </arguments>
+            </block>
+            <block class="Magebit\CheckoutQuickPayPayment\Block\QuickPay"
+                   name="checkout.payment.method.quickpay_googlepay"
+                   as="quickpay_googlepay"
+                   template="Magebit_CheckoutQuickPayPayment::component/payment/method/quickpay.phtml">
+                <arguments>
+                    <argument name="method_code" xsi:type="string">quickpay_googlepay</argument>
+                </arguments>
+            </block>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/templates/component/payment/method/quickpay.phtml
+++ b/view/frontend/templates/component/payment/method/quickpay.phtml
@@ -18,15 +18,16 @@ $config = $block->getPaymentConfigByMethod($methodCode);
 
 $logos = $config['paymentLogo'] ?? [];
 $description = $config['description'] ?? '';
-
+$label = $config['label'] ?? '';
 ?>
+
 <?php /* The wire Payment Method directive is required to sit in the root DOM element. */ ?>
 
 <div class="quickpay-method" data-method="<?= $escaper->escapeHtmlAttr($methodCode) ?>">
     <?php if (!empty($logos)): ?>
         <div class="quickpay-logos flex items-center space-x-2">
             <?php foreach ($logos as $logo): ?>
-                <img src="<?= $escaper->escapeUrl($logo) ?>" alt="Payment Logo" class="h-8"/>
+                <img src="<?= $escaper->escapeUrl($logo) ?>" alt="<?= $escaper->escapeHtmlAttr($label) ?>" class="h-8"/>
             <?php endforeach; ?>
         </div>
     <?php endif; ?>

--- a/view/frontend/templates/component/payment/method/quickpay.phtml
+++ b/view/frontend/templates/component/payment/method/quickpay.phtml
@@ -25,9 +25,9 @@ $label = $config['label'] ?? '';
 
 <div class="quickpay-method" data-method="<?= $escaper->escapeHtmlAttr($methodCode) ?>">
     <?php if (!empty($logos)): ?>
-        <div class="quickpay-logos flex items-center space-x-2">
+        <div class="quickpay-logos flex flex-wrap items-center gap-1.5">
             <?php foreach ($logos as $logo): ?>
-                <img src="<?= $escaper->escapeUrl($logo) ?>" alt="<?= $escaper->escapeHtmlAttr($label) ?>" class="h-8"/>
+                <img src="<?= $escaper->escapeUrl($logo) ?>" alt="<?= $escaper->escapeHtmlAttr($label) ?>" width="50" height="33"/>
             <?php endforeach; ?>
         </div>
     <?php endif; ?>

--- a/view/frontend/templates/component/payment/method/quickpay.phtml
+++ b/view/frontend/templates/component/payment/method/quickpay.phtml
@@ -8,13 +8,34 @@
 declare(strict_types=1);
 
 use Magento\Framework\Escaper;
-use Magento\Framework\View\Element\Template;
+use Magebit\CheckoutQuickPayPayment\Block\QuickPay;
 
-/** @var Template $block */
+/** @var QuickPay $block */
 /** @var Escaper $escaper */
+
+$methodCode = $block->getMethodCode();
+$config = $block->getPaymentConfigByMethod($methodCode);
+
+$logos = $config['paymentLogo'] ?? [];
+$description = $config['description'] ?? '';
 
 ?>
 <?php /* The wire Payment Method directive is required to sit in the root DOM element. */ ?>
+
+<div class="quickpay-method" data-method="<?= $escaper->escapeHtmlAttr($methodCode) ?>">
+    <?php if (!empty($logos)): ?>
+        <div class="quickpay-logos flex items-center space-x-2">
+            <?php foreach ($logos as $logo): ?>
+                <img src="<?= $escaper->escapeUrl($logo) ?>" alt="Payment Logo" class="h-8"/>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+    <?php if ($description): ?>
+        <div class="quickpay-description mt-3 p-4 mb-1 bg-gray-100 rounded-lg">
+            <?= $escaper->escapeHtml($description) ?>
+        </div>
+    <?php endif; ?>
+</div>
 <div>
     <p class="p-4 bg-gray-100 rounded-lg">
         <?= __('You will be redirected to the QuickPay Gateway to complete payment.') ?>

--- a/view/frontend/templates/component/payment/method/quickpay.phtml
+++ b/view/frontend/templates/component/payment/method/quickpay.phtml
@@ -37,8 +37,3 @@ $label = $config['label'] ?? '';
         </div>
     <?php endif; ?>
 </div>
-<div>
-    <p class="p-4 bg-gray-100 rounded-lg">
-        <?= __('You will be redirected to the QuickPay Gateway to complete payment.') ?>
-    </p>
-</div>


### PR DESCRIPTION
### Preconditions (*)
Magebit_CheckoutQuickPayPayment module version : 1.0.0

### Description (*)
When adding a description for a payment method or selecting card logo, the description and logo are not displayed on the frontend checkout page.

Screenshot 1:
<img width="1476" height="882" alt="image" src="https://github.com/user-attachments/assets/170300e0-162b-438f-9eea-86e7c0056ef1" />
### Steps to reproduce (*)
1.Go to Admin > Stores > Configuration > Sales > Payment Methods.
2.Select a QuickPay payment method
3.Add a description and select the card logos to display on the checkout page.
4.Go to the frontend checkout page and observe the payment method description and logos are not showing.
### Expected result (*)
Payment method description and logo should appear on the frontend checkout page.
### Actual result (*)
Payment method description and logo are not showing on the frontend checkout page.
